### PR TITLE
fix: Mobile details page looking off

### DIFF
--- a/pages/phones/Phone.jsx
+++ b/pages/phones/Phone.jsx
@@ -48,7 +48,7 @@ export default function PhonePage({
             <Image
               src={image}
               alt={phoneName}
-              width={250}
+              width={200}
               height={250}
               quality={100}
             />

--- a/styles/Phone.module.css
+++ b/styles/Phone.module.css
@@ -88,7 +88,8 @@
 }
 
 .details div {
-	margin-left: 20px;
+	/* margin-left: 20px; */
+	margin: 5px 20px;
 }
 
 .details h3 {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Closes #11 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## 👨‍💻 Changes proposed(required)

<!-- List all the proposed changes in your PR -->

* add a margin distance between "details" divs in Phone page, like seen in `Screenshot_1`
* fix stretched image and adjust its resolution to make it more "contained" (`Screenshot_1`)

## ✔️ Check List (Check all the applicable boxes)(required) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers

<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots
### Before
![Before](https://user-images.githubusercontent.com/72851613/187062737-31891217-9876-4087-8a6f-c477031254e8.png)
### After
![Screenshot_1](https://user-images.githubusercontent.com/59806140/187075007-6a929457-85d3-4c8a-8212-7857ae5a6059.png)

